### PR TITLE
Remove superfluous lastEdited field, which was overriding other $set objects

### DIFF
--- a/db/dbReducer.ts
+++ b/db/dbReducer.ts
@@ -16,7 +16,6 @@ const dbReducer = async (
 ): Promise<void> => {
 	const updateMetaFields = {
 		$inc: { __v: 1 },
-		$set: { lastEdited: Date.now() },
 	};
 	if (action.type === "item_add") {
 		//# Add An Item


### PR DESCRIPTION
Mongoose's `timestamps` option is automatically adding and updating `createdAt` and `updatedAt` properties.

The `$set` in `updateMetaFields` was overriding the `$set` in both `item_update` and `sheet_metadataUpdate` actions when destructured into the object.