### PR TITLE
(HOTFIX) Iphone button fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Bug Fixes -->
 
+## Version 1.0.1a (Hotfix)
+
+### Bug Fixes:
+
+- Fixed a problem where dialog action buttons could sometimes be covered by the safari bottom navigation bar when viewed on certain models of iPhone
+
 ## Version 1.0.1
 
 ### Features

--- a/components/ui/Dialog.tsx
+++ b/components/ui/Dialog.tsx
@@ -37,6 +37,7 @@ const Dialog: React.FC<DialogProps> = ({
 	<Modal {...props}>
 		{!noOverlay && <ModalOverlay />}
 		<ModalContent marginBottom={32}>
+			{/* //? Extra Margin Bottom to stop bottom action buttons being covered by safari navigation bar */}
 			{header && <ModalHeader>{header}</ModalHeader>}
 			{!noCloseButton && <ModalCloseButton />}
 			{children}

--- a/components/ui/Dialog.tsx
+++ b/components/ui/Dialog.tsx
@@ -36,7 +36,7 @@ const Dialog: React.FC<DialogProps> = ({
 }) => (
 	<Modal {...props}>
 		{!noOverlay && <ModalOverlay />}
-		<ModalContent>
+		<ModalContent marginBottom={32}>
 			{header && <ModalHeader>{header}</ModalHeader>}
 			{!noCloseButton && <ModalCloseButton />}
 			{children}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rpg-party-inventory",
-	"version": "1.0.2",
+	"version": "1.0.1a",
 	"private": true,
 	"scripts": {
 		"start:dev": "next dev",


### PR DESCRIPTION
Fixed a problem where dialog action buttons could sometimes be covered by the safari bottom navigation bar when viewed on certain models of iPhone.

Resolves issue #20