### PR TITLE
fix(frontend): :bug: searching is no longer case sensitive

### DIFF
--- a/src/state/sheetPageState.ts
+++ b/src/state/sheetPageState.ts
@@ -143,7 +143,9 @@ export const useSheetPageState = () => {
 
 		//* Filter items
 		let result = [...sorted].filter((item) =>
-			item.name.includes(state.ui.searchbarValue.value)
+			item.name
+				.toLowerCase()
+				.includes(state.ui.searchbarValue.value.toLowerCase())
 		);
 		for (const [property, filter] of Object.entries(state.filters.value)) {
 			result = result.filter((item) => !filter.includes(item[property]));


### PR DESCRIPTION
Search Query and item names are now converted to lowercase before being compared

Resolves #102